### PR TITLE
fix(core): DuplicateDMLOperation handles JSON-sourced boolean flow metadata

### DIFF
--- a/packages/core/src/main/rules/DuplicateDMLOperation.ts
+++ b/packages/core/src/main/rules/DuplicateDMLOperation.ts
@@ -48,8 +48,8 @@ export class DuplicateDMLOperation extends RuleCommon implements IRuleDefinition
       if (
         nextSeenDML &&
         node.subtype === "screens" &&
-        node.element["allowBack"] === "true" &&
-        node.element["showFooter"] === "true" &&
+        this.isTrue(node.element["allowBack"]) &&
+        this.isTrue(node.element["showFooter"]) &&
         !suppressions.has(node.name)
       ) {
         violations.push(new core.Violation(node));
@@ -60,7 +60,7 @@ export class DuplicateDMLOperation extends RuleCommon implements IRuleDefinition
       if (
         nextSeenDML &&
         node.subtype === "screens" &&
-        node.element["allowBack"] !== "true"
+        !this.isTrue(node.element["allowBack"])
       ) {
         nextSeenDML = false;
       }
@@ -79,5 +79,11 @@ export class DuplicateDMLOperation extends RuleCommon implements IRuleDefinition
       node.subtype === "recordUpdates" ||
       node.subtype === "recordDeletes"
     );
+  }
+
+  // XML-parsed flows carry the string "true"; flows built from Tooling API
+  // JSON (e.g. the Salesforce app) carry a real boolean.
+  private isTrue(value: unknown): boolean {
+    return value === true || String(value).toLowerCase() === "true";
   }
 }

--- a/packages/core/tests/DuplicateDMLOperation.test.ts
+++ b/packages/core/tests/DuplicateDMLOperation.test.ts
@@ -3,6 +3,39 @@ import * as path from "path";
 
 import * as core from "../src";
 
+const jsonRuleConfig = {
+  ruleMode: "isolated",
+  rules: {
+    DuplicateDMLOperation: {
+      severity: "error",
+    },
+  },
+};
+
+// Mirrors the shape produced by the Salesforce app when it fetches
+// Flow.Metadata via the Tooling API - booleans are real booleans, not the
+// "true"/"false" strings XML parsing yields.
+function buildJsonFlow(screens: Record<string, unknown>[]): core.Flow {
+  const flowObj = {
+    label: "Duplicate DML Operation JSON",
+    processType: "Flow",
+    status: "Active",
+    recordCreates: {
+      name: "createAccount",
+      label: "createAccount",
+      connector: { targetReference: screens[0].name },
+      inputAssignments: { field: "Name", value: { elementReference: "account_name" } },
+      object: "Account",
+      storeOutputAutomatically: true,
+    },
+    screens,
+    start: {
+      connector: { targetReference: "createAccount" },
+    },
+  };
+  return new core.Flow("json-test-flow", flowObj);
+}
+
 describe("DuplicateDMLOperation  ", () => {
   const example_uri = path.join(__dirname, "../../../example-flows/force-app/demo/Duplicate_DML_Operation.flow-meta.xml");
   const fixed_uri = path.join(__dirname, "../../../example-flows/force-app/testing/Duplicate_DML_Operation_Fixed.flow-meta.xml");
@@ -37,6 +70,46 @@ describe("DuplicateDMLOperation  ", () => {
     };
 
     const results: core.ScanResult[] = core.scan(flows, ruleConfig);
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults).toHaveLength(0);
+  });
+
+  it("should report a violation for a JSON-sourced flow with real boolean allowBack/showFooter", async () => {
+    const flow = buildJsonFlow([
+      {
+        name: "mock_screen_1",
+        label: "mock screen 1",
+        allowBack: true,
+        showFooter: true,
+      },
+    ]);
+    const parsedFlow = new core.ParsedFlow("json-test-flow", flow);
+
+    const results: core.ScanResult[] = core.scan([parsedFlow], jsonRuleConfig);
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults).toHaveLength(1);
+    expect(occurringResults[0].ruleName).toBe("DuplicateDMLOperation");
+  });
+
+  it("should reset the seen-DML flag on a JSON-sourced back-disabled screen (real boolean false)", async () => {
+    const flow = buildJsonFlow([
+      {
+        name: "mock_screen_1",
+        label: "mock screen 1",
+        allowBack: false,
+        showFooter: true,
+        connector: { targetReference: "mock_screen_2" },
+      },
+      {
+        name: "mock_screen_2",
+        label: "mock screen 2",
+        allowBack: true,
+        showFooter: true,
+      },
+    ]);
+    const parsedFlow = new core.ParsedFlow("json-test-flow", flow);
+
+    const results: core.ScanResult[] = core.scan([parsedFlow], jsonRuleConfig);
     const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
     expect(occurringResults).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- `DuplicateDMLOperation` compared `allowBack`/`showFooter` strictly against the string `"true"`, so flows built from Tooling API JSON (real booleans, e.g. the Salesforce app fetching `Flow.Metadata`) never matched: violations went unreported and the back-disabled reset never fired.
- Added a small `isTrue` helper (matches the coercion pattern already used in `MissingNullHandler.ts` and `RecordIdAsString.ts`) and used it in all three comparisons.

## Scope note
Evaluated the "coerce booleans once at Flow construction" structural alternative suggested on the ticket. Decided against it for this fix: it would touch shared `Flow`/`FlowNode` parsing broadly for every rule, which is a bigger blast radius than this scoped bug warrants. The local `isTrue` helper matches the existing per-rule pattern and is the minimal correct fix.

Rollout to `force-app/main/default/staticresources/LFS_Core.js` in the LFS Salesforce app repo is a separate follow-up once this lands in a core release — not bundled into an unreleased build here.

## Test plan
- [x] New regression test: JSON-shaped flow (real booleans) reports the violation
- [x] New regression test: JSON-shaped flow verifies the back-disabled reset clears the seen-DML flag
- [x] Existing XML-based tests still pass
- [x] `npx jest` — full core suite green except pre-existing, unrelated `SanityTest.test.ts` UMD-global failure (confirmed present on `main` before this change, needs a UMD build artifact)
- [x] `tsc --noEmit` clean

Plane: LFS-15