### PR TITLE
ci(core): make npm trusted publishing actually work

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -19,11 +19,14 @@ jobs:
       
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
-      - name: Configure npm registry
-        run: npm config set registry https://registry.npmjs.org/
+      # Trusted publishing needs npm 11.5.1 or newer; the bundled npm is older
+      # and falls back to token auth, which fails with ENEEDAUTH.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The `Publish Core to npm` job has never published anything. Both `core-v6.19.3` runs (28704784548, 28704858844) failed at the last step:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

Cause: `setup-node` pinned Node 20, which bundles npm 10.x. OIDC trusted publishing landed in npm 11.5.1, so npm never attempted the token exchange despite `id-token: write` — it fell back to token auth, and the repo has no `NPM_TOKEN` secret (only `PATX`). 6.19.3 and 6.19.4 on npm were published by hand and carry no provenance attestation.

This change:
- Node 24 instead of 20
- `npm install -g npm@latest` so the runner has OIDC support
- `registry-url` on `setup-node` instead of a separate `npm config set registry` step

**Still required outside this repo:** a trusted publisher must be registered for `@flow-scanner/lightning-flow-scanner-core` on npmjs.com (package settings), naming this repository and `publish-core.yml`. Without it the exchange is rejected and the job will fail again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)