### PR TITLE
fix(security): prevent ReDoS in UnusedVariable (GHSA-fpvw-w7ff-h7vr)

### DIFF
--- a/example-flows/force-app/testing/Unused_Variable_ReDoS.flow-meta.xml
+++ b/example-flows/force-app/testing/Unused_Variable_ReDoS.flow-meta.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <areMetricsLoggedToDataCloud>false</areMetricsLoggedToDataCloud>
+    <description>Crafted variable name that would ReDoS unescaped RegExp(variableName, &quot;gi&quot;).</description>
+    <environments>Default</environments>
+    <interviewLabel>Unused Variable ReDoS {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Unused Variable ReDoS</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>Flow</processType>
+    <screens>
+        <name>mock_screen</name>
+        <label>mock screen</label>
+        <locationX>176</locationX>
+        <locationY>134</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>true</allowPause>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>mock_screen</targetReference>
+        </connector>
+    </start>
+    <status>Active</status>
+    <variables>
+        <!-- Pathological pattern: exponential backtracking under new RegExp(name, "gi") -->
+        <name>(a+)+$</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaab</stringValue>
+        </value>
+    </variables>
+</Flow>

--- a/packages/core/src/main/rules/UnusedVariable.ts
+++ b/packages/core/src/main/rules/UnusedVariable.ts
@@ -2,6 +2,35 @@ import * as core from "../internals/internals";
 import { RuleCommon } from "../models/RuleCommon";
 import { IRuleDefinition } from "../interfaces/IRuleDefinition";
 
+/**
+ * Count non-overlapping case-insensitive literal occurrences of `needle` in `haystack`.
+ *
+ * Variable names come from scanned Flow metadata and must never be compiled as RegExp
+ * patterns (CWE-1333 / GHSA-fpvw-w7ff-h7vr). This preserves the previous "gi" substring
+ * semantics without invoking the regex engine.
+ */
+export function countLiteralOccurrences(haystack: string, needle: string): number {
+  if (!needle) {
+    return 0;
+  }
+
+  const lowerHaystack = haystack.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  let count = 0;
+  let fromIndex = 0;
+
+  while (fromIndex <= lowerHaystack.length - lowerNeedle.length) {
+    const foundAt = lowerHaystack.indexOf(lowerNeedle, fromIndex);
+    if (foundAt === -1) {
+      break;
+    }
+    count += 1;
+    fromIndex = foundAt + lowerNeedle.length;
+  }
+
+  return count;
+}
+
 export class UnusedVariable extends RuleCommon implements IRuleDefinition {
   constructor() {
     super({
@@ -9,7 +38,8 @@ export class UnusedVariable extends RuleCommon implements IRuleDefinition {
       category: "layout",
       name: "UnusedVariable",
       label: "Unused Variable",
-      description: "Unused variables are never referenced and add unnecessary clutter. Remove them to keep Flows efficient and easy to maintain.",
+      description:
+        "Unused variables are never referenced and add unnecessary clutter. Remove them to keep Flows efficient and easy to maintain.",
       summary: "Unused variables add clutter and hurt maintainability",
       supportedTypes: [...core.FlowType.backEndTypes, ...core.FlowType.visualTypes],
       docRefs: [],
@@ -26,38 +56,34 @@ export class UnusedVariable extends RuleCommon implements IRuleDefinition {
       (node) => node instanceof core.FlowVariable
     ) as core.FlowVariable[];
 
+    // Serialize once per collection — same search surface as before, without per-variable RegExp.
+    const nodesJson = JSON.stringify(
+      flow.elements.filter((node) => node instanceof core.FlowNode)
+    );
+    const resourcesJson = JSON.stringify(
+      flow.elements.filter((node) => node instanceof core.FlowResource)
+    );
+    const variablesJson = JSON.stringify(
+      flow.elements.filter((node) => node instanceof core.FlowVariable)
+    );
+
     const unusedVariables: core.FlowVariable[] = [];
 
     for (const variable of variables) {
       const variableName = variable.name;
 
-      const nodeMatches = [
-        ...JSON.stringify(flow.elements.filter((node) => node instanceof core.FlowNode)).matchAll(
-          new RegExp(variableName, "gi")
-        ),
-      ].map((a) => a.index);
+      if (countLiteralOccurrences(nodesJson, variableName) > 0) {
+        continue;
+      }
 
-      if (nodeMatches.length > 0) continue;
+      if (countLiteralOccurrences(resourcesJson, variableName) > 0) {
+        continue;
+      }
 
-      const resourceMatches = [
-        ...JSON.stringify(flow.elements.filter((node) => node instanceof core.FlowResource)).matchAll(
-          new RegExp(variableName, "gi")
-        ),
-      ].map((a) => a.index);
+      const insideCounter = countLiteralOccurrences(JSON.stringify(variable), variableName);
+      const variableUsage = countLiteralOccurrences(variablesJson, variableName);
 
-      if (resourceMatches.length > 0) continue;
-
-      const insideCounter = [
-        ...JSON.stringify(variable).matchAll(new RegExp(variable.name, "gi")),
-      ].map((a) => a.index);
-
-      const variableUsage = [
-        ...JSON.stringify(flow.elements.filter((node) => node instanceof core.FlowVariable)).matchAll(
-          new RegExp(variableName, "gi")
-        ),
-      ].map((a) => a.index);
-
-      if (variableUsage.length === insideCounter.length) {
+      if (variableUsage === insideCounter) {
         unusedVariables.push(variable);
       }
     }

--- a/packages/core/tests/UnusedVariable.security.test.ts
+++ b/packages/core/tests/UnusedVariable.security.test.ts
@@ -1,0 +1,67 @@
+import * as core from "../src";
+import * as path from "path";
+import { countLiteralOccurrences } from "../src/main/rules/UnusedVariable";
+
+import { describe, it, expect } from "@jest/globals";
+
+describe("UnusedVariable security (GHSA-fpvw-w7ff-h7vr)", () => {
+  const redos_uri = path.join(
+    __dirname,
+    "../../../example-flows/force-app/testing/Unused_Variable_ReDoS.flow-meta.xml"
+  );
+
+  const ruleConfig = {
+    ruleMode: "isolated" as const,
+    rules: {
+      UnusedVariable: {
+        severity: "error",
+      },
+    },
+  };
+
+  it("countLiteralOccurrences is case-insensitive and literal", () => {
+    expect(countLiteralOccurrences("Foo bar FOO", "foo")).toBe(2);
+    expect(countLiteralOccurrences("aaaa", "aa")).toBe(2);
+    expect(countLiteralOccurrences("hello", "(a+)+$")).toBe(0);
+    expect(countLiteralOccurrences("x(a+)+$y", "(a+)+$")).toBe(1);
+    expect(countLiteralOccurrences("anything", "")).toBe(0);
+  });
+
+  it("completes quickly and flags unused variable with ReDoS-shaped name", async () => {
+    const flows = await core.parse([redos_uri]);
+    const started = Date.now();
+    const results: core.ScanResult[] = core.scan(flows, ruleConfig);
+    const elapsedMs = Date.now() - started;
+
+    // Unescaped RegExp('(a+)+$', 'gi') on long subjects stalls for many seconds.
+    // Literal matching must finish well under a second on this fixture.
+    expect(elapsedMs).toBeLessThan(2000);
+
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults).toHaveLength(1);
+    expect(occurringResults[0].details[0].name).toBe("(a+)+$");
+  });
+
+  it("still detects usage when a regex-special variable name is referenced", async () => {
+    // Build on the ReDoS fixture: mark the variable used via a screen field reference text.
+    const flows = await core.parse([redos_uri]);
+    const flow = flows[0].flow!;
+    const screen = flow.elements.find((el) => el.name === "mock_screen") as any;
+    expect(screen).toBeDefined();
+
+    // Inject a literal reference into both fields and element so stringify sees the name.
+    const fields = [
+      {
+        name: "display",
+        fieldText: "Value: {!((a+)+$)}",
+        fieldType: "DisplayText",
+      },
+    ];
+    screen.fields = fields;
+    screen.element = { ...(screen.element ?? {}), fields };
+
+    const results: core.ScanResult[] = core.scan(flows, ruleConfig);
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes the ReDoS in the `UnusedVariable` rule reported as GHSA-fpvw-w7ff-h7vr.

- Rewrites the vulnerable pattern matching in `packages/core/src/main/rules/UnusedVariable.ts`
- Adds `packages/core/tests/UnusedVariable.security.test.ts` with a regression case
- Adds a malicious fixture at `Unused_Variable_ReDoS.flow-meta.xml`

Core suite: 39 suites / 149 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)