### PR TITLE
docs: put the availability note under the demo GIF in package READMEs

### DIFF
--- a/.github/scripts/update-package-readmes.js
+++ b/.github/scripts/update-package-readmes.js
@@ -159,6 +159,9 @@ const packageGifs = {
 `
 };
 
+// Availability note — moved below the demo GIF in package READMEs
+const AVAILABILITY_NOTE = /\n*<p align="center">Also available in[\s\S]*?<\/p>\n*/;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Sync function — fully stable, GIF always injected
 function syncPackageReadme(packagePath, packageName) {
@@ -191,11 +194,24 @@ function syncPackageReadme(packagePath, packageName) {
     // Remove the trailing --- and any whitespace around it
     newHeader = sharedHeader.replace(/\s*---\s*$/, '').trimEnd();
 
+    // In the root README the availability note sits directly under the subtitle.
+    // Package READMEs lead with the demo GIF, so the note belongs below it.
+    let availabilityNote = '';
+    const availabilityMatch = newHeader.match(AVAILABILITY_NOTE);
+    if (availabilityMatch) {
+      availabilityNote = availabilityMatch[0].trim();
+      newHeader = newHeader.replace(AVAILABILITY_NOTE, '\n\n').trimEnd();
+    }
+
     // Ensure exactly two blank lines before the GIF
     newHeader += '\n\n';
 
     // Add the GIF block
     newHeader += gifBlockTrimmed + '\n\n';
+
+    if (availabilityNote) {
+      newHeader += availabilityNote + '\n\n';
+    }
 
     // Add the separator with exactly one blank line before it
     newHeader += '---\n';

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -27,13 +27,13 @@
 
 <p align="center"><i>Detect unsafe contexts, queries in loops, hardcoded IDs, and more to optimize Salesforce Flows</i></p>
 
-<p align="center">Also available in the <a href="https://chromewebstore.google.com/detail/salesforce-inspector-relo/hpijlohoihegkfehhibggnkbjhoemldh"><b>Salesforce Inspector Reloaded</b></a> extension and <a href="https://appexchange.salesforce.com/appxListingDetail?listingId=a0N4V00000HA0X2UAL"><b>Org Check</b></a> app</p>
-
 <p align="center">
   <a href="https://github.com/Flow-Scanner">
     <img src="https://raw.githubusercontent.com/Flow-Scanner/Lightning-Flow-Scanner/main/docs/media/action.gif"/>
   </a>
 </p>
+
+<p align="center">Also available in the <a href="https://chromewebstore.google.com/detail/salesforce-inspector-relo/hpijlohoihegkfehhibggnkbjhoemldh"><b>Salesforce Inspector Reloaded</b></a> extension and <a href="https://appexchange.salesforce.com/appxListingDetail?listingId=a0N4V00000HA0X2UAL"><b>Org Check</b></a> app</p>
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,11 +27,11 @@
 
 <p align="center"><i>Detect unsafe contexts, queries in loops, hardcoded IDs, and more to optimize Salesforce Flows</i></p>
 
-<p align="center">Also available in the <a href="https://chromewebstore.google.com/detail/salesforce-inspector-relo/hpijlohoihegkfehhibggnkbjhoemldh"><b>Salesforce Inspector Reloaded</b></a> extension and <a href="https://appexchange.salesforce.com/appxListingDetail?listingId=a0N4V00000HA0X2UAL"><b>OrgCheck</b></a> app</p>
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/Flow-Scanner/Lightning-Flow-Scanner/main/docs/media/cli-demo.gif" alt="Flow Overview"/>
 </p>
+
+<p align="center">Also available in the <a href="https://chromewebstore.google.com/detail/salesforce-inspector-relo/hpijlohoihegkfehhibggnkbjhoemldh"><b>Salesforce Inspector Reloaded</b></a> extension and <a href="https://appexchange.salesforce.com/appxListingDetail?listingId=a0N4V00000HA0X2UAL"><b>Org Check</b></a> app</p>
 
 ---
 

--- a/packages/vsx/README.md
+++ b/packages/vsx/README.md
@@ -27,11 +27,11 @@
 
 <p align="center"><i>Detect unsafe contexts, queries in loops, hardcoded IDs, and more to optimize Salesforce Flows</i></p>
 
-<p align="center">Also available in the <a href="https://chromewebstore.google.com/detail/salesforce-inspector-relo/hpijlohoihegkfehhibggnkbjhoemldh"><b>Salesforce Inspector Reloaded</b></a> extension and <a href="https://appexchange.salesforce.com/appxListingDetail?listingId=a0N4V00000HA0X2UAL"><b>OrgCheck</b></a> app</p>
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/Flow-Scanner/Lightning-Flow-Scanner/main/docs/media/vsx-demo.gif" alt="Flow Overview"/>
 </p>
+
+<p align="center">Also available in the <a href="https://chromewebstore.google.com/detail/salesforce-inspector-relo/hpijlohoihegkfehhibggnkbjhoemldh"><b>Salesforce Inspector Reloaded</b></a> extension and <a href="https://appexchange.salesforce.com/appxListingDetail?listingId=a0N4V00000HA0X2UAL"><b>Org Check</b></a> app</p>
 
 ---
 


### PR DESCRIPTION
Two things:

- `update-package-readmes.js` now relocates the "Also available in …" note below the per-package demo GIF. In the root README it stays directly under the subtitle.
- Regenerated `cli`, `vsx` and `action` READMEs, which also propagates the `OrgCheck` → `Org Check` name fix from #312 (cli and vsx were still stale).