### PR TITLE
release(cli): 6.19.5 on core 6.19.4

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,42 @@
+name: Publish CLI to npm
+on:
+  push:
+    tags:
+      - "cli-v*"  # Use cli-v1.0.0 for CLI releases
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  publish-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing needs npm 11.5.1 or newer; the bundled npm is older
+      # and falls back to token auth, which fails with ENEEDAUTH.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI
+        run: pnpm run build:cli
+
+      # pnpm pack rewrites the workspace:* core dependency to the released version.
+      - name: Pack
+        working-directory: packages/cli
+        run: pnpm pack --pack-destination /tmp
+
+      - name: Publish
+        run: npm publish /tmp/lightning-flow-scanner-*.tgz --provenance --access public

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-flow-scanner",
-  "version": "6.19.4",
+  "version": "6.19.5",
   "bugs": "https://github.com/Flow-Scanner/lightning-flow-scanner/issues",
   "description": "A Salesforce CLI plugin for analysis and optimization of Salesforce Flow. Scans metadata for 20+ issues such as hardcoded IDs, unsafe contexts, inefficient SOQL/DML operations, recursion risks, and missing fault handling. Supports auto-fixes, rule configurations, and CI/CD integration to help users maintain secure and reliable Flow automations.",
   "dependencies": {


### PR DESCRIPTION
The CLI published as 6.19.4 pins core **6.19.3** — `workspace:*` resolves at pack time, so the ReDoS fix never reached CLI users.

- Bumps CLI to 6.19.5; verified the packed tarball pins `@flow-scanner/lightning-flow-scanner-core: 6.19.4`
- Adds `publish-cli.yml`, mirroring the core workflow: `cli-v*` tag → trusted publishing (OIDC, no token) → provenance attestation
- CLI suite: 14 passing