### PR TITLE
release(vsx): 3.4.3 on core 6.19.4

### DIFF
--- a/packages/vsx/package.json
+++ b/packages/vsx/package.json
@@ -10,7 +10,7 @@
   },
   "icon": "media/lightningflow.png",
   "description": "A VS Code Extension for analysis and optimization of Salesforce Flows. Scans metadata for 20+ issues such as hardcoded IDs, unsafe contexts, inefficient SOQL/DML operations, recursion risks, and missing fault handling. Supports auto-fixes, rule configurations, and tests integration.",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "engines": {
     "vscode": "^1.92.0"
   },


### PR DESCRIPTION
The extension webpacks core in at build time, so 3.4.2 on the Marketplace still carries the vulnerable `UnusedVariable`.

Verified: unpacked `lightning-flow-scanner-vsx-3.4.3.vsix` and confirmed `extension/dist/extension.js` contains the rewritten rule, not the old RegExp path.