### PR TITLE
release(vsx): 3.4.4

### DIFF
--- a/packages/vsx/package.json
+++ b/packages/vsx/package.json
@@ -10,7 +10,7 @@
   },
   "icon": "media/lightningflow.png",
   "description": "A VS Code Extension for analysis and optimization of Salesforce Flows. Scans metadata for 20+ issues such as hardcoded IDs, unsafe contexts, inefficient SOQL/DML operations, recursion risks, and missing fault handling. Supports auto-fixes, rule configurations, and tests integration.",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "engines": {
     "vscode": "^1.92.0"
   },


### PR DESCRIPTION
The Marketplace already serves 3.4.3 (published a month ago) while the repo manifest still said 3.4.2, so #315's bump to 3.4.3 collided with a live version. This takes it to 3.4.4.

Verified the packed `.vsix` bundles the fixed `UnusedVariable` (GHSA-fpvw-w7ff-h7vr).